### PR TITLE
feat: extended auth flows + RBAC system

### DIFF
--- a/.sisyphus/notepads/task-10/decisions.md
+++ b/.sisyphus/notepads/task-10/decisions.md
@@ -1,0 +1,3 @@
+## 2026-04-26
+- Kept tenant role assignments in `tenant_members` and reserved `user_roles` for global roles to preserve the current schema and avoid introducing a new tenant-scoped role mapping table.
+- Scoped admin user listing, lookup, updates, and effective permission reads by `tenant_id` only when a tenant context header is present.

--- a/.sisyphus/notepads/task-10/issues.md
+++ b/.sisyphus/notepads/task-10/issues.md
@@ -1,0 +1,2 @@
+## 2026-04-26
+- Existing Docker volume state caused `sqlx` migration version mismatch for `202604260003`; resetting with `docker-compose down -v` was required before runtime verification.

--- a/.sisyphus/notepads/task-10/learnings.md
+++ b/.sisyphus/notepads/task-10/learnings.md
@@ -1,0 +1,3 @@
+## 2026-04-26
+- Tenant RBAC works cleanly by combining global `users.role_id`/`user_roles` permissions with tenant-scoped `tenant_members.role_id` permissions instead of overloading `user_roles` with tenant IDs.
+- Admin endpoints should treat tenant context as explicit via `X-Tenant-ID`; otherwise global RBAC checks become unintentionally tenant-scoped because access tokens already carry a default tenant.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,5 @@ tracing-subscriber = { version = "0.3.20", features = ["env-filter", "fmt"] }
 uuid = { version = "1.18.1", features = ["serde", "v4"] }
 validator = { version = "0.20.0", features = ["derive"] }
 argon2 = "0.5.3"
+rand = "0.9"
+base64-url = "2"

--- a/migrations/202604260003_add_rbac_tables.sql
+++ b/migrations/202604260003_add_rbac_tables.sql
@@ -21,20 +21,29 @@ INSERT INTO permissions (name, description) VALUES
     ('users.read', 'View users'),
     ('users.write', 'Create and update users'),
     ('users.delete', 'Delete users'),
-    ('roles.manage', 'Manage roles and permissions')
+    ('roles.manage', 'Manage roles and permissions'),
+    ('tenant:create', 'Create tenants'),
+    ('tenant:manage', 'Manage tenant roles and members'),
+    ('tenant:invite', 'Invite users to tenants'),
+    ('tenant:members:read', 'View tenant members')
 ON CONFLICT (name) DO NOTHING;
 
 INSERT INTO role_permissions (role_id, permission_id)
 SELECT r.id, p.id FROM roles r CROSS JOIN permissions p
-WHERE r.name = 'super_admin' AND p.name IN ('users.read', 'users.write', 'users.delete', 'roles.manage')
+WHERE r.name = 'super_admin' AND p.name IN ('users.read', 'users.write', 'users.delete', 'roles.manage', 'tenant:create', 'tenant:manage', 'tenant:invite', 'tenant:members:read')
 ON CONFLICT DO NOTHING;
 
 INSERT INTO role_permissions (role_id, permission_id)
 SELECT r.id, p.id FROM roles r CROSS JOIN permissions p
-WHERE r.name = 'admin' AND p.name IN ('users.read', 'users.write')
+WHERE r.name = 'admin' AND p.name IN ('users.read', 'users.write', 'tenant:create', 'tenant:manage', 'tenant:invite', 'tenant:members:read')
 ON CONFLICT DO NOTHING;
 
 INSERT INTO role_permissions (role_id, permission_id)
 SELECT r.id, p.id FROM roles r CROSS JOIN permissions p
-WHERE r.name = 'user' AND p.name = 'users.read'
+WHERE r.name = 'tenant_admin' AND p.name IN ('users.read', 'users.write', 'tenant:manage', 'tenant:invite', 'tenant:members:read')
+ON CONFLICT DO NOTHING;
+
+INSERT INTO role_permissions (role_id, permission_id)
+SELECT r.id, p.id FROM roles r CROSS JOIN permissions p
+WHERE r.name = 'tenant_member' AND p.name IN ('users.read', 'tenant:members:read')
 ON CONFLICT DO NOTHING;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -126,6 +126,10 @@ impl AppError {
     pub fn bad_request(message: impl Into<String>) -> Self {
         Self::new("BAD_REQUEST", message, StatusCode::BAD_REQUEST)
     }
+
+    pub fn conflict(message: impl Into<String>) -> Self {
+        Self::new("CONFLICT", message, StatusCode::CONFLICT)
+    }
 }
 
 impl IntoResponse for AppError {

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ mod state;
 use axum::{Router, middleware::from_fn_with_state};
 use config::Settings;
 use middleware::{auth::require_auth, tenant::resolve_tenant_context};
-use routes::{admin, auth::auth_routes, health::health_routes};
+use routes::{admin, auth::auth_routes, health::health_routes, tenant};
 use services::tenant::{BASE_MIGRATOR, TenantSchemaService};
 use state::AppState;
 use std::net::SocketAddr;
@@ -33,6 +33,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .merge(health_routes())
         .nest("/api/v1/auth", auth_routes(state.clone()))
         .nest("/api/v1/admin", admin::admin_routes().layer(from_fn_with_state(state.clone(), require_auth)))
+        .nest("/api/v1/tenants", tenant::tenant_routes().layer(from_fn_with_state(state.clone(), require_auth)))
         .layer(from_fn_with_state(state.clone(), resolve_tenant_context))
         .layer(TraceLayer::new_for_http())
         .with_state(state);

--- a/src/middleware/tenant.rs
+++ b/src/middleware/tenant.rs
@@ -15,14 +15,7 @@ pub async fn resolve_tenant_context(
         .headers()
         .get("X-Tenant-ID")
         .and_then(|value| value.to_str().ok())
-        .and_then(|value| Uuid::parse_str(value).ok())
-        .or_else(|| {
-            bearer_token(request.headers())
-                .ok()
-                .and_then(|token| state.token_service.decode_token(&token).ok())
-                .and_then(|claims| claims.tenant_id)
-                .and_then(|value| Uuid::parse_str(&value).ok())
-        });
+        .and_then(|value| Uuid::parse_str(value).ok());
 
     if let Some(tenant_id) = tenant_id {
         let user_id = bearer_token(request.headers())

--- a/src/models/permission.rs
+++ b/src/models/permission.rs
@@ -24,34 +24,82 @@ impl Permission {
             .await
     }
 
-    pub async fn find_by_user_id(pool: &PgPool, user_id: Uuid) -> Result<Vec<Self>, sqlx::Error> {
+    pub async fn find_by_user_id(
+        pool: &PgPool,
+        user_id: Uuid,
+        tenant_id: Option<Uuid>,
+    ) -> Result<Vec<Self>, sqlx::Error> {
         sqlx::query_as::<_, Self>(
             r#"
-            SELECT p.id, p.name, p.description, p.created_at
+            SELECT DISTINCT p.id, p.name, p.description, p.created_at
             FROM permissions p
             JOIN role_permissions rp ON rp.permission_id = p.id
-            JOIN user_roles ur ON ur.role_id = rp.role_id
-            WHERE ur.user_id = $1
+            WHERE rp.role_id = (SELECT role_id FROM users WHERE id = $1)
+               OR EXISTS (
+                    SELECT 1
+                    FROM user_roles ur
+                    WHERE ur.user_id = $1
+                      AND ur.role_id = rp.role_id
+               )
+               OR (
+                    $2::uuid IS NOT NULL
+                    AND EXISTS (
+                        SELECT 1
+                        FROM tenant_members tm
+                        WHERE tm.user_id = $1
+                          AND tm.tenant_id = $2
+                          AND tm.is_active = TRUE
+                          AND tm.role_id = rp.role_id
+                    )
+               )
+            ORDER BY p.name
             "#,
         )
         .bind(user_id)
+        .bind(tenant_id)
         .fetch_all(pool)
         .await
     }
 
-    pub async fn user_has_permission(pool: &PgPool, user_id: Uuid, permission_name: &str) -> Result<bool, sqlx::Error> {
+    pub async fn user_has_permission(
+        pool: &PgPool,
+        user_id: Uuid,
+        permission_name: &str,
+        tenant_id: Option<Uuid>,
+    ) -> Result<bool, sqlx::Error> {
         let result = sqlx::query_scalar::<_, bool>(
             r#"
             SELECT EXISTS(
-                SELECT 1 FROM permissions p
+                SELECT 1
+                FROM permissions p
                 JOIN role_permissions rp ON rp.permission_id = p.id
-                JOIN user_roles ur ON ur.role_id = rp.role_id
-                WHERE ur.user_id = $1 AND p.name = $2
+                WHERE p.name = $2
+                  AND (
+                        rp.role_id = (SELECT role_id FROM users WHERE id = $1)
+                     OR EXISTS (
+                            SELECT 1
+                            FROM user_roles ur
+                            WHERE ur.user_id = $1
+                              AND ur.role_id = rp.role_id
+                        )
+                     OR (
+                            $3::uuid IS NOT NULL
+                            AND EXISTS (
+                                SELECT 1
+                                FROM tenant_members tm
+                                WHERE tm.user_id = $1
+                                  AND tm.tenant_id = $3
+                                  AND tm.is_active = TRUE
+                                  AND tm.role_id = rp.role_id
+                            )
+                        )
+                  )
             )
             "#,
         )
         .bind(user_id)
         .bind(permission_name)
+        .bind(tenant_id)
         .fetch_one(pool)
         .await?;
         Ok(result)

--- a/src/models/role.rs
+++ b/src/models/role.rs
@@ -3,6 +3,9 @@ use serde::{Deserialize, Serialize};
 use sqlx::{FromRow, PgPool};
 use uuid::Uuid;
 
+const GLOBAL_ROLE_NAMES: [&str; 3] = ["super_admin", "admin", "user"];
+const TENANT_ROLE_NAMES: [&str; 2] = ["tenant_admin", "tenant_member"];
+
 #[allow(dead_code)]
 #[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
 pub struct Role {
@@ -17,5 +20,40 @@ impl Role {
         sqlx::query_as::<_, Self>("SELECT id, name, description, created_at FROM roles ORDER BY name")
             .fetch_all(pool)
             .await
+    }
+
+    pub async fn find_by_id(pool: &PgPool, role_id: Uuid) -> Result<Option<Self>, sqlx::Error> {
+        sqlx::query_as::<_, Self>(
+            "SELECT id, name, description, created_at FROM roles WHERE id = $1",
+        )
+        .bind(role_id)
+        .fetch_optional(pool)
+        .await
+    }
+
+    pub async fn global_roles(pool: &PgPool) -> Result<Vec<Self>, sqlx::Error> {
+        sqlx::query_as::<_, Self>(
+            "SELECT id, name, description, created_at FROM roles WHERE name = ANY($1) ORDER BY name",
+        )
+        .bind(&GLOBAL_ROLE_NAMES)
+        .fetch_all(pool)
+        .await
+    }
+
+    pub async fn tenant_roles(pool: &PgPool) -> Result<Vec<Self>, sqlx::Error> {
+        sqlx::query_as::<_, Self>(
+            "SELECT id, name, description, created_at FROM roles WHERE name = ANY($1) ORDER BY name",
+        )
+        .bind(&TENANT_ROLE_NAMES)
+        .fetch_all(pool)
+        .await
+    }
+
+    pub fn is_tenant_scoped(&self) -> bool {
+        Self::is_tenant_role_name(&self.name)
+    }
+
+    pub fn is_tenant_role_name(role_name: &str) -> bool {
+        TENANT_ROLE_NAMES.contains(&role_name)
     }
 }

--- a/src/models/user_role.rs
+++ b/src/models/user_role.rs
@@ -4,13 +4,50 @@ use uuid::Uuid;
 pub struct UserRole;
 
 impl UserRole {
-    pub async fn assign(pool: &PgPool, user_id: Uuid, role_id: Uuid) -> Result<(), sqlx::Error> {
+    pub async fn assign_global(
+        pool: &PgPool,
+        user_id: Uuid,
+        role_id: Uuid,
+    ) -> Result<(), sqlx::Error> {
+        let mut transaction = pool.begin().await?;
+
+        sqlx::query("UPDATE users SET role_id = $1, updated_at = NOW() WHERE id = $2")
+            .bind(role_id)
+            .bind(user_id)
+            .execute(&mut *transaction)
+            .await?;
+
+        sqlx::query("DELETE FROM user_roles WHERE user_id = $1")
+            .bind(user_id)
+            .execute(&mut *transaction)
+            .await?;
+
         sqlx::query("INSERT INTO user_roles (user_id, role_id) VALUES ($1, $2) ON CONFLICT DO NOTHING")
             .bind(user_id)
             .bind(role_id)
-            .execute(pool)
+            .execute(&mut *transaction)
             .await?;
+
+        transaction.commit().await?;
         Ok(())
+    }
+
+    pub async fn assign_tenant(
+        pool: &PgPool,
+        tenant_id: Uuid,
+        user_id: Uuid,
+        role_id: Uuid,
+    ) -> Result<bool, sqlx::Error> {
+        let result = sqlx::query(
+            "UPDATE tenant_members SET role_id = $1 WHERE tenant_id = $2 AND user_id = $3 AND is_active = TRUE",
+        )
+        .bind(role_id)
+        .bind(tenant_id)
+        .bind(user_id)
+        .execute(pool)
+        .await?;
+
+        Ok(result.rows_affected() > 0)
     }
 
     pub async fn remove(pool: &PgPool, user_id: Uuid, role_id: Uuid) -> Result<(), sqlx::Error> {

--- a/src/routes/admin.rs
+++ b/src/routes/admin.rs
@@ -20,6 +20,7 @@ use crate::{
         user_role::UserRole as UserRoleModel,
     },
     response::ok,
+    services::tenant::TenantContext,
     state::AppState,
 };
 
@@ -36,14 +37,91 @@ pub fn admin_routes() -> Router<AppState> {
         .route("/users/roles", post(assign_role_to_user))
 }
 
-async fn require_perm(pool: &PgPool, user_id: Uuid, perm: &str) -> Result<(), AppError> {
-    let has = Permission::user_has_permission(pool, user_id, perm)
-        .await
-        .map_err(|_| AppError::internal("Permission check failed."))?;
-    if !has {
-        return Err(AppError::forbidden(&format!("Permission '{}' is required.", perm)));
+async fn require_any_perm(
+    pool: &PgPool,
+    user_id: Uuid,
+    tenant_id: Option<Uuid>,
+    permissions: &[&str],
+) -> Result<(), AppError> {
+    for permission in permissions {
+        if Permission::user_has_permission(pool, user_id, permission, tenant_id)
+            .await
+            .map_err(|_| AppError::internal("Permission check failed."))?
+        {
+            return Ok(());
+        }
     }
+
+    let required = permissions.join(" or ");
+    Err(AppError::forbidden(&format!(
+        "Permission '{}' is required.",
+        required
+    )))
+}
+
+fn tenant_scope(context: &Option<Extension<TenantContext>>) -> Option<Uuid> {
+    context.as_ref().map(|Extension(context)| context.tenant_id)
+}
+
+fn tenant_permissions(tenant_id: Option<Uuid>, global_permission: &'static str, tenant_permission: &'static str) -> Vec<&'static str> {
+    if tenant_id.is_some() {
+        vec![global_permission, tenant_permission]
+    } else {
+        vec![global_permission]
+    }
+}
+
+async fn load_role(pool: &PgPool, role_id: Uuid) -> Result<Role, AppError> {
+    Role::find_by_id(pool, role_id)
+        .await?
+        .ok_or_else(|| AppError::not_found("Role not found."))
+}
+
+fn ensure_role_matches_scope(role: &Role, tenant_id: Option<Uuid>) -> Result<(), AppError> {
+    if tenant_id.is_some() && !role.is_tenant_scoped() {
+        return Err(AppError::forbidden(
+            "Only tenant roles can be used in tenant context.",
+        ));
+    }
+
+    if tenant_id.is_none() && role.is_tenant_scoped() {
+        return Err(AppError::forbidden(
+            "Tenant-scoped roles require a tenant context.",
+        ));
+    }
+
     Ok(())
+}
+
+async fn fetch_user(
+    pool: &PgPool,
+    user_id: Uuid,
+    tenant_id: Option<Uuid>,
+) -> Result<User, AppError> {
+    match tenant_id {
+        Some(tenant_id) => sqlx::query_as::<_, User>(
+            r#"
+            SELECT u.id, u.email, u.password_hash, u.first_name, u.last_name, u.role_id, u.is_active, u.is_verified, u.created_at, u.updated_at
+            FROM users u
+            INNER JOIN tenant_members tm ON tm.user_id = u.id
+            WHERE u.id = $1
+              AND tm.tenant_id = $2
+              AND tm.is_active = TRUE
+            "#,
+        )
+        .bind(user_id)
+        .bind(tenant_id)
+        .fetch_optional(pool)
+        .await?
+        .ok_or_else(|| AppError::not_found("User not found.")),
+        None => sqlx::query_as::<_, User>(
+            "SELECT id, email, password_hash, first_name, last_name, role_id, is_active, is_verified, created_at, updated_at FROM users WHERE id = $1",
+        )
+        .bind(user_id)
+        .fetch_optional(pool)
+        .await?
+        .ok_or_else(|| AppError::not_found("User not found.")),
+    }
 }
 
 #[derive(Serialize)]
@@ -53,122 +131,330 @@ struct RoleOut { id: Uuid, name: String, description: String, created_at: DateTi
 struct PermOut { id: Uuid, name: String, description: String, created_at: DateTime<Utc> }
 
 #[derive(Serialize)]
-struct UserOut { id: Uuid, email: String, first_name: String, last_name: String, is_active: bool, is_verified: bool, created_at: DateTime<Utc>, updated_at: DateTime<Utc> }
+struct UserOut { id: Uuid, email: String, first_name: String, last_name: String, is_active: bool, is_verified: bool, tenant_id: Option<Uuid>, created_at: DateTime<Utc>, updated_at: DateTime<Utc> }
 
-fn user_to_out(u: &User) -> UserOut {
-    UserOut { id: u.id, email: u.email.clone(), first_name: u.first_name.clone(), last_name: u.last_name.clone(), is_active: u.is_active, is_verified: u.is_verified, created_at: u.created_at, updated_at: u.updated_at }
+fn user_to_out(u: &User, tenant_id: Option<Uuid>) -> UserOut {
+    UserOut { id: u.id, email: u.email.clone(), first_name: u.first_name.clone(), last_name: u.last_name.clone(), is_active: u.is_active, is_verified: u.is_verified, tenant_id, created_at: u.created_at, updated_at: u.updated_at }
 }
 
-async fn list_roles(State(state): State<AppState>, Extension(auth): Extension<AuthUser>) -> Response {
-    match require_perm(&state.pool, auth.user_id, "roles.manage").await {
-        Err(e) => e.into_response(),
-        Ok(()) => {
-            match Role::all(&state.pool).await {
-                Ok(roles) => ok(roles.into_iter().map(|r| RoleOut { id: r.id, name: r.name, description: r.description, created_at: r.created_at }).collect::<Vec<_>>()).into_response(),
-                Err(e) => AppError::from(e).into_response(),
-            }
-        }
+async fn list_roles(
+    State(state): State<AppState>,
+    Extension(auth): Extension<AuthUser>,
+    tenant_context: Option<Extension<TenantContext>>,
+) -> Response {
+    match list_roles_inner(&state, auth.user_id, tenant_scope(&tenant_context)).await {
+        Ok(response) => response,
+        Err(error) => error.into_response(),
     }
 }
 
-async fn list_permissions(State(state): State<AppState>, Extension(auth): Extension<AuthUser>) -> Response {
-    match require_perm(&state.pool, auth.user_id, "roles.manage").await {
-        Err(e) => e.into_response(),
-        Ok(()) => {
-            match Permission::all(&state.pool).await {
-                Ok(perms) => ok(perms.into_iter().map(|p| PermOut { id: p.id, name: p.name, description: p.description, created_at: p.created_at }).collect::<Vec<_>>()).into_response(),
-                Err(e) => AppError::from(e).into_response(),
-            }
-        }
+async fn list_roles_inner(
+    state: &AppState,
+    user_id: Uuid,
+    tenant_id: Option<Uuid>,
+) -> Result<Response, AppError> {
+    let permissions = tenant_permissions(tenant_id, "roles.manage", "tenant:manage");
+    require_any_perm(&state.pool, user_id, tenant_id, &permissions).await?;
+
+    let roles = match tenant_id {
+        Some(_) => Role::tenant_roles(&state.pool).await?,
+        None => Role::global_roles(&state.pool).await?,
+    };
+
+    Ok(ok(roles.into_iter().map(|role| RoleOut {
+        id: role.id,
+        name: role.name,
+        description: role.description,
+        created_at: role.created_at,
+    }).collect::<Vec<_>>()).into_response())
+}
+
+async fn list_permissions(
+    State(state): State<AppState>,
+    Extension(auth): Extension<AuthUser>,
+    tenant_context: Option<Extension<TenantContext>>,
+) -> Response {
+    match list_permissions_inner(&state, auth.user_id, tenant_scope(&tenant_context)).await {
+        Ok(response) => response,
+        Err(error) => error.into_response(),
     }
 }
 
-async fn get_role_permissions(State(state): State<AppState>, Extension(auth): Extension<AuthUser>, Path(role_id): Path<Uuid>) -> Response {
-    match require_perm(&state.pool, auth.user_id, "roles.manage").await {
-        Err(e) => e.into_response(),
-        Ok(()) => {
-            match Permission::find_by_role_id(&state.pool, role_id).await {
-                Ok(perms) => ok(perms.into_iter().map(|p| PermOut { id: p.id, name: p.name, description: p.description, created_at: p.created_at }).collect::<Vec<_>>()).into_response(),
-                Err(e) => AppError::from(e).into_response(),
-            }
-        }
+async fn list_permissions_inner(
+    state: &AppState,
+    user_id: Uuid,
+    tenant_id: Option<Uuid>,
+) -> Result<Response, AppError> {
+    let permissions = tenant_permissions(tenant_id, "roles.manage", "tenant:manage");
+    require_any_perm(&state.pool, user_id, tenant_id, &permissions).await?;
+
+    let all_permissions = Permission::all(&state.pool).await?;
+    Ok(ok(all_permissions.into_iter().map(|permission| PermOut {
+        id: permission.id,
+        name: permission.name,
+        description: permission.description,
+        created_at: permission.created_at,
+    }).collect::<Vec<_>>()).into_response())
+}
+
+async fn get_role_permissions(
+    State(state): State<AppState>,
+    Extension(auth): Extension<AuthUser>,
+    tenant_context: Option<Extension<TenantContext>>,
+    Path(role_id): Path<Uuid>,
+) -> Response {
+    match get_role_permissions_inner(&state, auth.user_id, tenant_scope(&tenant_context), role_id)
+        .await
+    {
+        Ok(response) => response,
+        Err(error) => error.into_response(),
     }
 }
 
-async fn assign_permission_to_role(State(state): State<AppState>, Extension(auth): Extension<AuthUser>, Json(payload): Json<RolePermReq>) -> Response {
-    match require_perm(&state.pool, auth.user_id, "roles.manage").await {
-        Err(e) => e.into_response(),
-        Ok(()) => {
-            match Permission::assign_to_role(&state.pool, payload.role_id, payload.permission_id).await {
-                Ok(()) => ok(serde_json::json!({"message": "Permission assigned to role."})).into_response(),
-                Err(e) => AppError::from(e).into_response(),
-            }
-        }
+async fn get_role_permissions_inner(
+    state: &AppState,
+    user_id: Uuid,
+    tenant_id: Option<Uuid>,
+    role_id: Uuid,
+) -> Result<Response, AppError> {
+    let permissions = tenant_permissions(tenant_id, "roles.manage", "tenant:manage");
+    require_any_perm(&state.pool, user_id, tenant_id, &permissions).await?;
+
+    let role = load_role(&state.pool, role_id).await?;
+    ensure_role_matches_scope(&role, tenant_id)?;
+
+    let role_permissions = Permission::find_by_role_id(&state.pool, role_id).await?;
+    Ok(ok(role_permissions.into_iter().map(|permission| PermOut {
+        id: permission.id,
+        name: permission.name,
+        description: permission.description,
+        created_at: permission.created_at,
+    }).collect::<Vec<_>>()).into_response())
+}
+
+async fn assign_permission_to_role(
+    State(state): State<AppState>,
+    Extension(auth): Extension<AuthUser>,
+    tenant_context: Option<Extension<TenantContext>>,
+    Json(payload): Json<RolePermReq>,
+) -> Response {
+    match assign_permission_to_role_inner(
+        &state,
+        auth.user_id,
+        tenant_scope(&tenant_context),
+        payload,
+    )
+    .await
+    {
+        Ok(response) => response,
+        Err(error) => error.into_response(),
     }
 }
 
-async fn list_users(State(state): State<AppState>, Extension(auth): Extension<AuthUser>) -> Response {
-    match require_perm(&state.pool, auth.user_id, "users.read").await {
-        Err(e) => e.into_response(),
-        Ok(()) => {
-            match sqlx::query_as::<_, User>("SELECT id, email, password_hash, first_name, last_name, role_id, is_active, is_verified, created_at, updated_at FROM users ORDER BY created_at DESC").fetch_all(&state.pool).await {
-                Ok(users) => ok(users.iter().map(user_to_out).collect::<Vec<_>>()).into_response(),
-                Err(e) => AppError::from(e).into_response(),
-            }
-        }
+async fn assign_permission_to_role_inner(
+    state: &AppState,
+    user_id: Uuid,
+    tenant_id: Option<Uuid>,
+    payload: RolePermReq,
+) -> Result<Response, AppError> {
+    require_any_perm(&state.pool, user_id, tenant_id, &["roles.manage"]).await?;
+    if tenant_id.is_some() {
+        return Err(AppError::forbidden(
+            "Tenant-scoped role permissions are seeded and cannot be changed here.",
+        ));
+    }
+
+    let role = load_role(&state.pool, payload.role_id).await?;
+    ensure_role_matches_scope(&role, tenant_id)?;
+    Permission::assign_to_role(&state.pool, payload.role_id, payload.permission_id).await?;
+
+    Ok(ok(serde_json::json!({"message": "Permission assigned to role."})).into_response())
+}
+
+async fn list_users(
+    State(state): State<AppState>,
+    Extension(auth): Extension<AuthUser>,
+    tenant_context: Option<Extension<TenantContext>>,
+) -> Response {
+    match list_users_inner(&state, auth.user_id, tenant_scope(&tenant_context)).await {
+        Ok(response) => response,
+        Err(error) => error.into_response(),
     }
 }
 
-async fn get_user(State(state): State<AppState>, Extension(auth): Extension<AuthUser>, Path(user_id): Path<Uuid>) -> Response {
-    match require_perm(&state.pool, auth.user_id, "users.read").await {
-        Err(e) => e.into_response(),
-        Ok(()) => {
-            match sqlx::query_as::<_, User>("SELECT id, email, password_hash, first_name, last_name, role_id, is_active, is_verified, created_at, updated_at FROM users WHERE id = $1").bind(user_id).fetch_optional(&state.pool).await {
-                Ok(Some(user)) => ok(user_to_out(&user)).into_response(),
-                Ok(None) => AppError::not_found("User not found.").into_response(),
-                Err(e) => AppError::from(e).into_response(),
-            }
-        }
+async fn list_users_inner(
+    state: &AppState,
+    user_id: Uuid,
+    tenant_id: Option<Uuid>,
+) -> Result<Response, AppError> {
+    let permissions = tenant_permissions(tenant_id, "users.read", "tenant:members:read");
+    require_any_perm(&state.pool, user_id, tenant_id, &permissions).await?;
+
+    let users = match tenant_id {
+        Some(tenant_id) => sqlx::query_as::<_, User>(
+            r#"
+            SELECT DISTINCT u.id, u.email, u.password_hash, u.first_name, u.last_name, u.role_id, u.is_active, u.is_verified, u.created_at, u.updated_at
+            FROM users u
+            INNER JOIN tenant_members tm ON tm.user_id = u.id
+            WHERE tm.tenant_id = $1
+              AND tm.is_active = TRUE
+            ORDER BY u.created_at DESC
+            "#,
+        )
+        .bind(tenant_id)
+        .fetch_all(&state.pool)
+        .await?,
+        None => sqlx::query_as::<_, User>(
+            "SELECT id, email, password_hash, first_name, last_name, role_id, is_active, is_verified, created_at, updated_at FROM users ORDER BY created_at DESC",
+        )
+        .fetch_all(&state.pool)
+        .await?,
+    };
+
+    Ok(ok(users.iter().map(|user| user_to_out(user, tenant_id)).collect::<Vec<_>>()).into_response())
+}
+
+async fn get_user(
+    State(state): State<AppState>,
+    Extension(auth): Extension<AuthUser>,
+    tenant_context: Option<Extension<TenantContext>>,
+    Path(user_id): Path<Uuid>,
+) -> Response {
+    match get_user_inner(&state, auth.user_id, tenant_scope(&tenant_context), user_id).await {
+        Ok(response) => response,
+        Err(error) => error.into_response(),
     }
 }
 
-async fn update_user(State(state): State<AppState>, Extension(auth): Extension<AuthUser>, Path(user_id): Path<Uuid>, Json(payload): Json<UserUpdateReq>) -> Response {
-    match require_perm(&state.pool, auth.user_id, "users.write").await {
-        Err(e) => e.into_response(),
-        Ok(()) => {
-            if let Some(ref v) = payload.first_name { let _ = sqlx::query("UPDATE users SET first_name=$1, updated_at=NOW() WHERE id=$2").bind(v).bind(user_id).execute(&state.pool).await; }
-            if let Some(ref v) = payload.last_name { let _ = sqlx::query("UPDATE users SET last_name=$1, updated_at=NOW() WHERE id=$2").bind(v).bind(user_id).execute(&state.pool).await; }
-            if let Some(v) = payload.is_active { let _ = sqlx::query("UPDATE users SET is_active=$1, updated_at=NOW() WHERE id=$2").bind(v).bind(user_id).execute(&state.pool).await; }
-            match sqlx::query_as::<_, User>("SELECT id, email, password_hash, first_name, last_name, role_id, is_active, is_verified, created_at, updated_at FROM users WHERE id=$1").bind(user_id).fetch_one(&state.pool).await {
-                Ok(user) => ok(user_to_out(&user)).into_response(),
-                Err(e) => AppError::from(e).into_response(),
-            }
-        }
+async fn get_user_inner(
+    state: &AppState,
+    auth_user_id: Uuid,
+    tenant_id: Option<Uuid>,
+    user_id: Uuid,
+) -> Result<Response, AppError> {
+    let permissions = tenant_permissions(tenant_id, "users.read", "tenant:members:read");
+    require_any_perm(&state.pool, auth_user_id, tenant_id, &permissions).await?;
+
+    let user = fetch_user(&state.pool, user_id, tenant_id).await?;
+    Ok(ok(user_to_out(&user, tenant_id)).into_response())
+}
+
+async fn update_user(
+    State(state): State<AppState>,
+    Extension(auth): Extension<AuthUser>,
+    tenant_context: Option<Extension<TenantContext>>,
+    Path(user_id): Path<Uuid>,
+    Json(payload): Json<UserUpdateReq>,
+) -> Response {
+    match update_user_inner(&state, auth.user_id, tenant_scope(&tenant_context), user_id, payload)
+        .await
+    {
+        Ok(response) => response,
+        Err(error) => error.into_response(),
     }
 }
 
-async fn get_user_permissions(State(state): State<AppState>, Extension(auth): Extension<AuthUser>, Path(target_id): Path<Uuid>) -> Response {
-    match require_perm(&state.pool, auth.user_id, "users.read").await {
-        Err(e) => e.into_response(),
-        Ok(()) => {
-            match Permission::find_by_user_id(&state.pool, target_id).await {
-                Ok(perms) => ok(perms.into_iter().map(|p| PermOut { id: p.id, name: p.name, description: p.description, created_at: p.created_at }).collect::<Vec<_>>()).into_response(),
-                Err(e) => AppError::from(e).into_response(),
-            }
-        }
+async fn update_user_inner(
+    state: &AppState,
+    auth_user_id: Uuid,
+    tenant_id: Option<Uuid>,
+    user_id: Uuid,
+    payload: UserUpdateReq,
+) -> Result<Response, AppError> {
+    let permissions = tenant_permissions(tenant_id, "users.write", "tenant:manage");
+    require_any_perm(&state.pool, auth_user_id, tenant_id, &permissions).await?;
+
+    let existing_user = fetch_user(&state.pool, user_id, tenant_id).await?;
+    let first_name = payload.first_name.unwrap_or(existing_user.first_name);
+    let last_name = payload.last_name.unwrap_or(existing_user.last_name);
+    let is_active = payload.is_active.unwrap_or(existing_user.is_active);
+
+    sqlx::query(
+        "UPDATE users SET first_name = $1, last_name = $2, is_active = $3, updated_at = NOW() WHERE id = $4",
+    )
+    .bind(&first_name)
+    .bind(&last_name)
+    .bind(is_active)
+    .bind(user_id)
+    .execute(&state.pool)
+    .await?;
+
+    let updated_user = fetch_user(&state.pool, user_id, tenant_id).await?;
+    Ok(ok(user_to_out(&updated_user, tenant_id)).into_response())
+}
+
+async fn get_user_permissions(
+    State(state): State<AppState>,
+    Extension(auth): Extension<AuthUser>,
+    tenant_context: Option<Extension<TenantContext>>,
+    Path(target_id): Path<Uuid>,
+) -> Response {
+    match get_user_permissions_inner(&state, auth.user_id, tenant_scope(&tenant_context), target_id)
+        .await
+    {
+        Ok(response) => response,
+        Err(error) => error.into_response(),
     }
 }
 
-async fn assign_role_to_user(State(state): State<AppState>, Extension(auth): Extension<AuthUser>, Json(payload): Json<UserRoleReq>) -> Response {
-    match require_perm(&state.pool, auth.user_id, "roles.manage").await {
-        Err(e) => e.into_response(),
-        Ok(()) => {
-            match UserRoleModel::assign(&state.pool, payload.user_id, payload.role_id).await {
-                Ok(()) => ok(serde_json::json!({"message": "Role assigned to user."})).into_response(),
-                Err(e) => AppError::from(e).into_response(),
+async fn get_user_permissions_inner(
+    state: &AppState,
+    auth_user_id: Uuid,
+    tenant_id: Option<Uuid>,
+    target_id: Uuid,
+) -> Result<Response, AppError> {
+    let permissions = tenant_permissions(tenant_id, "users.read", "tenant:members:read");
+    require_any_perm(&state.pool, auth_user_id, tenant_id, &permissions).await?;
+
+    let _ = fetch_user(&state.pool, target_id, tenant_id).await?;
+    let user_permissions = Permission::find_by_user_id(&state.pool, target_id, tenant_id).await?;
+    Ok(ok(user_permissions.into_iter().map(|permission| PermOut {
+        id: permission.id,
+        name: permission.name,
+        description: permission.description,
+        created_at: permission.created_at,
+    }).collect::<Vec<_>>()).into_response())
+}
+
+async fn assign_role_to_user(
+    State(state): State<AppState>,
+    Extension(auth): Extension<AuthUser>,
+    tenant_context: Option<Extension<TenantContext>>,
+    Json(payload): Json<UserRoleReq>,
+) -> Response {
+    match assign_role_to_user_inner(&state, auth.user_id, tenant_scope(&tenant_context), payload)
+        .await
+    {
+        Ok(response) => response,
+        Err(error) => error.into_response(),
+    }
+}
+
+async fn assign_role_to_user_inner(
+    state: &AppState,
+    auth_user_id: Uuid,
+    tenant_id: Option<Uuid>,
+    payload: UserRoleReq,
+) -> Result<Response, AppError> {
+    let role = load_role(&state.pool, payload.role_id).await?;
+    ensure_role_matches_scope(&role, tenant_id)?;
+
+    match tenant_id {
+        Some(tenant_id) => {
+            require_any_perm(&state.pool, auth_user_id, Some(tenant_id), &["roles.manage", "tenant:manage"]).await?;
+            let updated = UserRoleModel::assign_tenant(&state.pool, tenant_id, payload.user_id, payload.role_id).await?;
+            if !updated {
+                return Err(AppError::not_found("User not found in tenant."));
             }
         }
+        None => {
+            require_any_perm(&state.pool, auth_user_id, None, &["roles.manage"]).await?;
+            let _ = fetch_user(&state.pool, payload.user_id, None).await?;
+            UserRoleModel::assign_global(&state.pool, payload.user_id, payload.role_id).await?;
+        }
     }
+
+    Ok(ok(serde_json::json!({"message": "Role assigned to user."})).into_response())
 }
 
 #[derive(Deserialize)]

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -1,3 +1,4 @@
 pub mod admin;
 pub mod auth;
 pub mod health;
+pub mod tenant;

--- a/src/routes/tenant.rs
+++ b/src/routes/tenant.rs
@@ -1,0 +1,391 @@
+use axum::{
+    Extension,
+    extract::{Path, State},
+    routing::{delete, get, patch, post},
+    Json, Router,
+    response::{IntoResponse, Response},
+};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sha2::{Sha256, Digest};
+use uuid::Uuid;
+
+use crate::{
+    errors::AppError,
+    middleware::auth::AuthUser,
+    models::{role::Role, tenant::Tenant},
+    response::{created, ok},
+    state::AppState,
+};
+
+pub fn tenant_routes() -> Router<AppState> {
+    Router::new()
+        .route("/create", post(create_tenant))
+        .route("/list", get(list_my_tenants))
+        .route("/{tenant_id}", get(get_tenant))
+        .route("/{tenant_id}", patch(update_tenant))
+        .route("/{tenant_id}", delete(delete_tenant))
+        .route("/{tenant_id}/members", get(list_members))
+        .route("/{tenant_id}/invitations", post(invite_member))
+        .route("/{tenant_id}/invitations/accept", post(accept_invitation))
+        .route("/{tenant_id}/members/{user_id}/role", patch(update_member_role))
+        .route("/{tenant_id}/members/{user_id}", delete(remove_member))
+}
+
+async fn require_tenant_admin(pool: &sqlx::PgPool, tenant_id: Uuid, user_id: Uuid) -> Result<(), AppError> {
+    let result = sqlx::query_as::<_, (Uuid, String)>(
+        r#"SELECT tm.role_id, r.name FROM tenant_members tm JOIN roles r ON r.id = tm.role_id WHERE tm.tenant_id = $1 AND tm.user_id = $2 AND tm.is_active = TRUE"#
+    )
+    .bind(tenant_id)
+    .bind(user_id)
+    .fetch_optional(pool)
+    .await
+    .map_err(|e| AppError::internal(e.to_string()))?;
+
+    match result {
+        Some((_, role_name)) if role_name == "tenant_admin" || role_name == "super_admin" => Ok(()),
+        _ => Err(AppError::forbidden("Only tenant admins can perform this action.")),
+    }
+}
+
+async fn require_membership(pool: &sqlx::PgPool, tenant_id: Uuid, user_id: Uuid) -> Result<(), AppError> {
+    let is_member = sqlx::query_scalar::<_, bool>(
+        "SELECT EXISTS(SELECT 1 FROM tenant_members WHERE tenant_id = $1 AND user_id = $2 AND is_active = TRUE)"
+    )
+    .bind(tenant_id)
+    .bind(user_id)
+    .fetch_one(pool)
+    .await
+    .map_err(|e| AppError::internal(e.to_string()))?;
+
+    if !is_member {
+        return Err(AppError::forbidden("You are not a member of this tenant."));
+    }
+    Ok(())
+}
+
+#[derive(Serialize)]
+struct TenantOut {
+    id: Uuid,
+    name: String,
+    slug: String,
+    owner_id: Uuid,
+    is_active: bool,
+    created_at: DateTime<Utc>,
+    updated_at: DateTime<Utc>,
+}
+
+fn tenant_to_out(t: &Tenant) -> TenantOut {
+    TenantOut { id: t.id, name: t.name.clone(), slug: t.slug.clone(), owner_id: t.owner_id, is_active: t.is_active, created_at: t.created_at, updated_at: t.updated_at }
+}
+
+#[derive(Serialize)]
+struct MemberOut {
+    id: Uuid,
+    tenant_id: Uuid,
+    user_id: Uuid,
+    role_id: Uuid,
+    is_active: bool,
+    joined_at: DateTime<Utc>,
+    user_email: Option<String>,
+    role_name: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct CreateTenantReq {
+    name: String,
+    slug: String,
+}
+
+#[derive(Deserialize)]
+struct UpdateTenantReq {
+    name: Option<String>,
+    is_active: Option<bool>,
+}
+
+#[derive(Deserialize)]
+struct InviteReq {
+    email: String,
+    role_id: Uuid,
+}
+
+#[derive(Deserialize)]
+struct AcceptInviteReq {
+    token: String,
+}
+
+#[derive(Deserialize)]
+struct UpdateRoleReq {
+    role_id: Uuid,
+}
+
+async fn create_tenant(
+    State(state): State<AppState>,
+    Extension(auth): Extension<AuthUser>,
+    Json(payload): Json<CreateTenantReq>,
+) -> Response {
+    let tenant_admin_role_id = match state.tenant_schema_service.role_id_by_name("tenant_admin").await {
+        Ok(id) => id,
+        Err(e) => return e.into_response(),
+    };
+
+    match state.tenant_schema_service.create_tenant_record(
+        auth.user_id,
+        &payload.name,
+        &payload.slug.to_lowercase(),
+        tenant_admin_role_id,
+    ).await {
+        Ok(tenant) => created(tenant_to_out(&tenant)).into_response(),
+        Err(e) => AppError::from(e).into_response(),
+    }
+}
+
+async fn list_my_tenants(
+    State(state): State<AppState>,
+    Extension(auth): Extension<AuthUser>,
+) -> Response {
+    match sqlx::query_as::<_, Tenant>(
+        r#"SELECT t.id, t.name, t.slug, t.owner_id, t.is_active, t.created_at, t.updated_at
+           FROM tenants t
+           JOIN tenant_members tm ON tm.tenant_id = t.id
+           WHERE tm.user_id = $1 AND tm.is_active = TRUE AND t.is_active = TRUE
+           ORDER BY t.created_at DESC"#
+    )
+    .bind(auth.user_id)
+    .fetch_all(&state.pool)
+    .await {
+        Ok(tenants) => ok(tenants.iter().map(tenant_to_out).collect::<Vec<_>>()).into_response(),
+        Err(e) => AppError::from(e).into_response(),
+    }
+}
+
+async fn get_tenant(
+    State(state): State<AppState>,
+    Extension(auth): Extension<AuthUser>,
+    Path(tenant_id): Path<Uuid>,
+) -> Response {
+    if let Err(e) = require_membership(&state.pool, tenant_id, auth.user_id).await {
+        return e.into_response();
+    }
+    match sqlx::query_as::<_, Tenant>(
+        "SELECT id, name, slug, owner_id, is_active, created_at, updated_at FROM tenants WHERE id = $1 AND is_active = TRUE"
+    )
+    .bind(tenant_id)
+    .fetch_optional(&state.pool)
+    .await {
+        Ok(Some(t)) => ok(tenant_to_out(&t)).into_response(),
+        Ok(None) => AppError::not_found("Tenant not found.").into_response(),
+        Err(e) => AppError::from(e).into_response(),
+    }
+}
+
+async fn update_tenant(
+    State(state): State<AppState>,
+    Extension(auth): Extension<AuthUser>,
+    Path(tenant_id): Path<Uuid>,
+    Json(payload): Json<UpdateTenantReq>,
+) -> Response {
+    if let Err(e) = require_tenant_admin(&state.pool, tenant_id, auth.user_id).await {
+        return e.into_response();
+    }
+    if let Some(ref name) = payload.name {
+        let _ = sqlx::query("UPDATE tenants SET name = $1, updated_at = NOW() WHERE id = $2")
+            .bind(name).bind(tenant_id).execute(&state.pool).await;
+    }
+    if let Some(is_active) = payload.is_active {
+        let _ = sqlx::query("UPDATE tenants SET is_active = $1, updated_at = NOW() WHERE id = $2")
+            .bind(is_active).bind(tenant_id).execute(&state.pool).await;
+    }
+    match sqlx::query_as::<_, Tenant>(
+        "SELECT id, name, slug, owner_id, is_active, created_at, updated_at FROM tenants WHERE id = $1"
+    )
+    .bind(tenant_id)
+    .fetch_one(&state.pool)
+    .await {
+        Ok(t) => ok(tenant_to_out(&t)).into_response(),
+        Err(e) => AppError::from(e).into_response(),
+    }
+}
+
+async fn delete_tenant(
+    State(state): State<AppState>,
+    Extension(auth): Extension<AuthUser>,
+    Path(tenant_id): Path<Uuid>,
+) -> Response {
+    if let Err(e) = require_tenant_admin(&state.pool, tenant_id, auth.user_id).await {
+        return e.into_response();
+    }
+    match sqlx::query("UPDATE tenants SET is_active = FALSE, updated_at = NOW() WHERE id = $1")
+        .bind(tenant_id).execute(&state.pool).await {
+        Ok(_) => ok(serde_json::json!({"message": "Tenant deactivated."})).into_response(),
+        Err(e) => AppError::from(e).into_response(),
+    }
+}
+
+async fn list_members(
+    State(state): State<AppState>,
+    Extension(auth): Extension<AuthUser>,
+    Path(tenant_id): Path<Uuid>,
+) -> Response {
+    if let Err(e) = require_membership(&state.pool, tenant_id, auth.user_id).await {
+        return e.into_response();
+    }
+    match sqlx::query_as::<_, (Uuid, Uuid, Uuid, Uuid, bool, DateTime<Utc>, Option<String>, Option<String>)>(
+        r#"SELECT tm.id, tm.tenant_id, tm.user_id, tm.role_id, tm.is_active, tm.joined_at, u.email as user_email, r.name as role_name
+           FROM tenant_members tm
+           LEFT JOIN users u ON u.id = tm.user_id
+           LEFT JOIN roles r ON r.id = tm.role_id
+           WHERE tm.tenant_id = $1 AND tm.is_active = TRUE
+           ORDER BY tm.joined_at DESC"#
+    )
+    .bind(tenant_id)
+    .fetch_all(&state.pool)
+    .await {
+        Ok(rows) => ok(rows.into_iter().map(|(id, tid, uid, rid, active, joined, email, rname)| MemberOut {
+            id, tenant_id: tid, user_id: uid, role_id: rid, is_active: active, joined_at: joined, user_email: email, role_name: rname,
+        }).collect::<Vec<_>>()).into_response(),
+        Err(e) => AppError::from(e).into_response(),
+    }
+}
+
+async fn invite_member(
+    State(state): State<AppState>,
+    Extension(auth): Extension<AuthUser>,
+    Path(tenant_id): Path<Uuid>,
+    Json(payload): Json<InviteReq>,
+) -> Response {
+    if let Err(e) = require_tenant_admin(&state.pool, tenant_id, auth.user_id).await {
+        return e.into_response();
+    }
+    match sqlx::query_as::<_, Role>("SELECT id, name, description, created_at FROM roles WHERE id = $1")
+        .bind(payload.role_id).fetch_optional(&state.pool).await {
+        Ok(Some(_)) => {},
+        Ok(None) => return AppError::not_found("Role not found.").into_response(),
+        Err(e) => return AppError::from(e).into_response(),
+    }
+
+    let raw_token = generate_token();
+    let mut hasher = Sha256::new();
+    hasher.update(raw_token.as_bytes());
+    let token_hash = format!("{:x}", hasher.finalize());
+    let expires_at = Utc::now() + chrono::Duration::days(7);
+
+    match sqlx::query_scalar::<_, Uuid>(
+        r#"INSERT INTO tenant_invitations (id, tenant_id, email, role_id, token_hash, expires_at)
+           VALUES ($1, $2, $3, $4, $5, $6) RETURNING id"#
+    )
+    .bind(Uuid::new_v4())
+    .bind(tenant_id)
+    .bind(payload.email.to_lowercase())
+    .bind(payload.role_id)
+    .bind(&token_hash)
+    .bind(expires_at)
+    .fetch_one(&state.pool)
+    .await {
+        Ok(inv_id) => ok(serde_json::json!({
+            "id": inv_id.to_string(),
+            "tenant_id": tenant_id.to_string(),
+            "email": payload.email,
+            "role_id": payload.role_id.to_string(),
+            "expires_at": expires_at.to_rfc3339(),
+            "token": raw_token,
+        })).into_response(),
+        Err(e) => AppError::from(e).into_response(),
+    }
+}
+
+async fn accept_invitation(
+    State(state): State<AppState>,
+    Extension(auth): Extension<AuthUser>,
+    Path(_tenant_id): Path<Uuid>,
+    Json(payload): Json<AcceptInviteReq>,
+) -> Response {
+    let mut hasher = Sha256::new();
+    hasher.update(payload.token.as_bytes());
+    let token_hash = format!("{:x}", hasher.finalize());
+
+    let invitation = match sqlx::query_as::<_, (Uuid, Uuid, Uuid, Option<DateTime<Utc>>, DateTime<Utc>)>(
+        r#"SELECT id, tenant_id, role_id, accepted_at, expires_at FROM tenant_invitations WHERE token_hash = $1 AND accepted_at IS NULL"#
+    )
+    .bind(&token_hash)
+    .fetch_optional(&state.pool)
+    .await {
+        Ok(Some(inv)) => inv,
+        Ok(None) => return AppError::not_found("Invitation not found or already accepted.").into_response(),
+        Err(e) => return AppError::from(e).into_response(),
+    };
+
+    let (inv_id, inv_tenant_id, role_id, _, expires_at) = invitation;
+    if expires_at < Utc::now() {
+        return AppError::bad_request("Invitation has expired.").into_response();
+    }
+
+    let _ = sqlx::query("UPDATE tenant_invitations SET accepted_at = NOW() WHERE id = $1")
+        .bind(inv_id).execute(&state.pool).await;
+
+    let already = sqlx::query_scalar::<_, bool>(
+        "SELECT EXISTS(SELECT 1 FROM tenant_members WHERE tenant_id = $1 AND user_id = $2 AND is_active = TRUE)"
+    )
+    .bind(inv_tenant_id)
+    .bind(auth.user_id)
+    .fetch_one(&state.pool)
+    .await
+    .unwrap_or(false);
+
+    if already {
+        return AppError::conflict("User is already a member of this tenant.").into_response();
+    }
+
+    match sqlx::query_scalar::<_, Uuid>(
+        "INSERT INTO tenant_members (id, tenant_id, user_id, role_id, is_active) VALUES ($1, $2, $3, $4, TRUE) RETURNING id"
+    )
+    .bind(Uuid::new_v4())
+    .bind(inv_tenant_id)
+    .bind(auth.user_id)
+    .bind(role_id)
+    .fetch_one(&state.pool)
+    .await {
+        Ok(member_id) => ok(serde_json::json!({"message": "Invitation accepted.", "member_id": member_id.to_string()})).into_response(),
+        Err(e) => AppError::from(e).into_response(),
+    }
+}
+
+async fn update_member_role(
+    State(state): State<AppState>,
+    Extension(auth): Extension<AuthUser>,
+    Path((tenant_id, user_id)): Path<(Uuid, Uuid)>,
+    Json(payload): Json<UpdateRoleReq>,
+) -> Response {
+    if let Err(e) = require_tenant_admin(&state.pool, tenant_id, auth.user_id).await {
+        return e.into_response();
+    }
+    match sqlx::query("UPDATE tenant_members SET role_id = $1 WHERE tenant_id = $2 AND user_id = $3 AND is_active = TRUE")
+        .bind(payload.role_id).bind(tenant_id).bind(user_id).execute(&state.pool).await {
+        Ok(result) if result.rows_affected() > 0 => ok(serde_json::json!({"message": "Member role updated."})).into_response(),
+        Ok(_) => AppError::not_found("Member not found.").into_response(),
+        Err(e) => AppError::from(e).into_response(),
+    }
+}
+
+async fn remove_member(
+    State(state): State<AppState>,
+    Extension(auth): Extension<AuthUser>,
+    Path((tenant_id, user_id)): Path<(Uuid, Uuid)>,
+) -> Response {
+    if let Err(e) = require_tenant_admin(&state.pool, tenant_id, auth.user_id).await {
+        return e.into_response();
+    }
+    match sqlx::query("UPDATE tenant_members SET is_active = FALSE WHERE tenant_id = $1 AND user_id = $2 AND is_active = TRUE")
+        .bind(tenant_id).bind(user_id).execute(&state.pool).await {
+        Ok(result) if result.rows_affected() > 0 => ok(serde_json::json!({"message": "Member removed from tenant."})).into_response(),
+        Ok(_) => AppError::not_found("Member not found.").into_response(),
+        Err(e) => AppError::from(e).into_response(),
+    }
+}
+
+fn generate_token() -> String {
+    use rand::TryRngCore;
+    let mut bytes = [0u8; 32];
+    rand::rngs::OsRng.try_fill_bytes(&mut bytes).unwrap();
+    base64_url::encode(&bytes)
+}


### PR DESCRIPTION
## Summary
- cherry-pick the extended auth and baseline RBAC work onto `feature/extended-auth-rbac` from `feature/core-auth`
- add multi-tenant RBAC seeding and effective-permission resolution for global roles and tenant-scoped tenant_member/tenant_admin assignments
- scope admin user management to explicit tenant context and record implementation notes under `.sisyphus/notepads/task-10/`